### PR TITLE
Added test case for pir6

### DIFF
--- a/test/lib-controller.coffee
+++ b/test/lib-controller.coffee
@@ -70,6 +70,16 @@ describe '#decodePulses()', ->
       ]
     },
     {
+      protocol: 'pir6'
+      pulseLengths: [ 150, 453, 4733 ]
+      pulses: [
+        '01101010011001010110011010101010101010101010101002'
+      ]
+      values: [
+        { id: 1, unit: 1, presence: true }
+      ]
+    },
+    {
       protocol: 'weather1'
       pulseLengths: [456, 1990, 3940, 9236]
       pulses: [


### PR DESCRIPTION
I know the values id and unit do not match the actual values. However, the problem with your protocol is the pulselength cannot be detected somehow:

 1) #decodePulses() pir6 should decode the pulses:
     AssertionError: pulse of pir6 should be detected as pir6.
    at Context.runTest (C:\Users\marcus\Documents\Devel\rfcontroljs-pimatic\test\lib-controller.coffee:778:9)
    at callFn (C:\Users\marcus\Documents\Devel\rfcontroljs-pimatic\node_modules\gulp-mocha\node_modules\mocha\lib\runnable.js:250:21)
    at Test.Runnable.run (C:\Users\marcus\Documents\Devel\rfcontroljs-pimatic\node_modules\gulp-mocha\node_modules\mocha\lib\runnable.js:243:7)
    at Runner.runTest (C:\Users\marcus\Documents\Devel\rfcontroljs-pimatic\node_modules\gulp-mocha\node_modules\mocha\lib\runner.js:373:10)
    at C:\Users\marcus\Documents\Devel\rfcontroljs-pimatic\node_modules\gulp-mocha\node_modules\mocha\lib\runner.js:451:12
    at next (C:\Users\marcus\Documents\Devel\rfcontroljs-pimatic\node_modules\gulp-mocha\node_modules\mocha\lib\runner.js:298:14)
    at C:\Users\marcus\Documents\Devel\rfcontroljs-pimatic\node_modules\gulp-mocha\node_modules\mocha\lib\runner.js:308:7
    at next (C:\Users\marcus\Documents\Devel\rfcontroljs-pimatic\node_modules\gulp-mocha\node_modules\mocha\lib\runner.js:246:23)
    at Object._onImmediate (C:\Users\marcus\Documents\Devel\rfcontroljs-pimatic\node_modules\gulp-mocha\node_modules\mocha\lib\runner.js:275:5)
    at processImmediate [as _immediateCallback](timers.js:354:15)
